### PR TITLE
Allow Sqlizer instead of expr in UpdateBuilder values

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -109,6 +109,6 @@ func TestNullTypeInt64(t *testing.T) {
 	sql, args, err = b.ToSql()
 
 	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{10}, args)
+	assert.Equal(t, []interface{}{int64(10)}, args)
 	assert.Equal(t, "user_id = ?", sql)
 }


### PR DESCRIPTION
InsertBuilder allows Sqlizer to be used as value type, added same functionality to UpdateBuilder.