### PR TITLE
Allow Sqlizer as Expr arguments

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -112,3 +112,19 @@ func TestNullTypeInt64(t *testing.T) {
 	assert.Equal(t, []interface{}{int64(10)}, args)
 	assert.Equal(t, "user_id = ?", sql)
 }
+
+type dummySqlizer int
+
+func (d dummySqlizer) ToSql() (string, []interface{}, error) {
+	return "DUMMY(?, ?)", []interface{}{int(d), int(d)}, nil
+}
+
+func TestExprSqlizer(t *testing.T) {
+	b := Expr("EXISTS(?)", dummySqlizer(42))
+	sql, args, err := b.ToSql()
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "EXISTS(DUMMY(?, ?))", sql)
+		assert.Equal(t, []interface{}{42, 42}, args)
+	}
+}


### PR DESCRIPTION
Allow Sqlizer values to be used in expr.
To avoid overhead of creating buffer everytime old behaviour is used when no arguments match interface Sqlizer.

Example of usage:
```
sq.Select('foo', 'bar').From('baz').Where(Expr("EXISTS(?)",
  sq.Select('foo').From('bad').Where(Eq{"foo": 42})
))
```