### PR TITLE
Add support of context.Context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 
 go:
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
+  - 1.8
   - tip
 
 install:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ import "github.com/elgris/sqrl"
 [![GoDoc](https://godoc.org/github.com/elgris/sqrl?status.png)](https://godoc.org/github.com/elgris/sqrl)
 [![Build Status](https://travis-ci.org/elgris/sqrl.png?branch=master)](https://travis-ci.org/elgris/sqrl)
 
+**Requires Go 1.8 and higher**
+
 ## Inspired by
 
 - [squirrel](https://github.com/lann/squirrel)

--- a/delete.go
+++ b/delete.go
@@ -2,6 +2,7 @@ package sqrl
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"strconv"
@@ -42,10 +43,15 @@ func (b *DeleteBuilder) RunWith(runner BaseRunner) *DeleteBuilder {
 
 // Exec builds and Execs the query with the Runner set by RunWith.
 func (b *DeleteBuilder) Exec() (sql.Result, error) {
+	return b.ExecContext(context.Background())
+}
+
+// Exec builds and Execs the query with the Runner set by RunWith using given context.
+func (b *DeleteBuilder) ExecContext(ctx context.Context) (sql.Result, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-	return ExecWith(b.runWith, b)
+	return ExecWithContext(ctx, b.runWith, b)
 }
 
 // PlaceholderFormat sets PlaceholderFormat (e.g. Question or Dollar) for the

--- a/delete_test.go
+++ b/delete_test.go
@@ -1,6 +1,7 @@
 package sqrl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,11 +116,17 @@ func TestDeleteBuilderRunners(t *testing.T) {
 
 	b.Exec()
 	assert.Equal(t, expectedSql, db.LastExecSql)
+
+	b.ExecContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastExecSql)
 }
 
 func TestDeleteBuilderNoRunner(t *testing.T) {
 	b := Delete("test")
 
 	_, err := b.Exec()
+	assert.Equal(t, ErrRunnerNotSet, err)
+
+	_, err = b.ExecContext(context.TODO())
 	assert.Equal(t, ErrRunnerNotSet, err)
 }

--- a/insert.go
+++ b/insert.go
@@ -2,6 +2,7 @@ package sqrl
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -32,30 +33,45 @@ func (b *InsertBuilder) RunWith(runner BaseRunner) *InsertBuilder {
 
 // Exec builds and Execs the query with the Runner set by RunWith.
 func (b *InsertBuilder) Exec() (sql.Result, error) {
+	return b.ExecContext(context.Background())
+}
+
+// Exec builds and Execs the query with the Runner set by RunWith using given context.
+func (b *InsertBuilder) ExecContext(ctx context.Context) (sql.Result, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-	return ExecWith(b.runWith, b)
+	return ExecWithContext(ctx, b.runWith, b)
 }
 
 // Query builds and Querys the query with the Runner set by RunWith.
 func (b *InsertBuilder) Query() (*sql.Rows, error) {
+	return b.QueryContext(context.Background())
+}
+
+// QueryContext builds and runs the query using given context and Query command.
+func (b *InsertBuilder) QueryContext(ctx context.Context) (*sql.Rows, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-	return QueryWith(b.runWith, b)
+	return QueryWithContext(ctx, b.runWith, b)
 }
 
 // QueryRow builds and QueryRows the query with the Runner set by RunWith.
 func (b *InsertBuilder) QueryRow() RowScanner {
+	return b.QueryRowContext(context.Background())
+}
+
+// QueryRowContext builds and runs the query using given context.
+func (b *InsertBuilder) QueryRowContext(ctx context.Context) RowScanner {
 	if b.runWith == nil {
 		return &Row{err: ErrRunnerNotSet}
 	}
-	queryRower, ok := b.runWith.(QueryRower)
+	queryRower, ok := b.runWith.(QueryRowerContext)
 	if !ok {
-		return &Row{err: ErrRunnerNotQueryRunner}
+		return &Row{err: ErrRunnerNotQueryRunnerContext}
 	}
-	return QueryRowWith(queryRower, b)
+	return QueryRowWithContext(ctx, queryRower, b)
 }
 
 // Scan is a shortcut for QueryRow().Scan.

--- a/insert_test.go
+++ b/insert_test.go
@@ -1,6 +1,7 @@
 package sqrl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,12 +56,19 @@ func TestInsertBuilderRunners(t *testing.T) {
 
 	b.Exec()
 	assert.Equal(t, expectedSql, db.LastExecSql)
+
+	b.ExecContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastExecSql)
+
 }
 
 func TestInsertBuilderNoRunner(t *testing.T) {
 	b := Insert("test").Values(1)
 
 	_, err := b.Exec()
+	assert.Equal(t, ErrRunnerNotSet, err)
+
+	_, err = b.ExecContext(context.TODO())
 	assert.Equal(t, ErrRunnerNotSet, err)
 }
 

--- a/select.go
+++ b/select.go
@@ -2,6 +2,7 @@ package sqrl
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"strconv"
@@ -43,30 +44,44 @@ func (b *SelectBuilder) RunWith(runner BaseRunner) *SelectBuilder {
 
 // Exec builds and Execs the query with the Runner set by RunWith.
 func (b *SelectBuilder) Exec() (sql.Result, error) {
+	return b.ExecContext(context.Background())
+}
+
+// ExecContext builds and Execs the query with the Runner set by RunWith using given context.
+func (b *SelectBuilder) ExecContext(ctx context.Context) (sql.Result, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-	return ExecWith(b.runWith, b)
+	return ExecWithContext(ctx, b.runWith, b)
 }
 
 // Query builds and Querys the query with the Runner set by RunWith.
 func (b *SelectBuilder) Query() (*sql.Rows, error) {
+	return b.QueryContext(context.Background())
+}
+
+// QueryContext builds and Querys the query with the Runner set by RunWith in given context.
+func (b *SelectBuilder) QueryContext(ctx context.Context) (*sql.Rows, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-	return QueryWith(b.runWith, b)
+	return QueryWithContext(ctx, b.runWith, b)
 }
 
 // QueryRow builds and QueryRows the query with the Runner set by RunWith.
 func (b *SelectBuilder) QueryRow() RowScanner {
+	return b.QueryRowContext(context.Background())
+}
+
+func (b *SelectBuilder) QueryRowContext(ctx context.Context) RowScanner {
 	if b.runWith == nil {
 		return &Row{err: ErrRunnerNotSet}
 	}
-	queryRower, ok := b.runWith.(QueryRower)
+	queryRower, ok := b.runWith.(QueryRowerContext)
 	if !ok {
-		return &Row{err: ErrRunnerNotQueryRunner}
+		return &Row{err: ErrRunnerNotQueryRunnerContext}
 	}
-	return QueryRowWith(queryRower, b)
+	return QueryRowWithContext(ctx, queryRower, b)
 }
 
 // Scan is a shortcut for QueryRow().Scan.

--- a/select_test.go
+++ b/select_test.go
@@ -1,6 +1,7 @@
 package sqrl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,6 +127,15 @@ func TestSelectBuilderRunners(t *testing.T) {
 	b.QueryRow()
 	assert.Equal(t, expectedSql, db.LastQueryRowSql)
 
+	b.ExecContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastQueryRowSql)
+
+	b.QueryContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastQueryRowSql)
+
+	b.QueryRowContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastQueryRowSql)
+
 	err := b.Scan()
 	assert.NoError(t, err)
 }
@@ -137,6 +147,12 @@ func TestSelectBuilderNoRunner(t *testing.T) {
 	assert.Equal(t, ErrRunnerNotSet, err)
 
 	_, err = b.Query()
+	assert.Equal(t, ErrRunnerNotSet, err)
+
+	_, err = b.QueryContext(context.TODO())
+	assert.Equal(t, ErrRunnerNotSet, err)
+
+	_, err = b.ExecContext(context.TODO())
 	assert.Equal(t, ErrRunnerNotSet, err)
 
 	err = b.Scan()

--- a/sqrl.go
+++ b/sqrl.go
@@ -4,6 +4,7 @@
 package sqrl
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 )
@@ -23,11 +24,25 @@ type Execer interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 }
 
+// ExecerContext is the interface that wraps the Exec method.
+//
+// ExecContext executes the given query using given context as implemented by database/sql.ExecContext.
+type ExecerContext interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
 // Queryer is the interface that wraps the Query method.
 //
 // Query executes the given query as implemented by database/sql.Query.
 type Queryer interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// QueryerContext is the interface that wraps the Query method.
+//
+// QueryerContext executes the given query using given context as implemented by database/sql.QueryContext.
+type QueryerContext interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 }
 
 // QueryRower is the interface that wraps the QueryRow method.
@@ -37,34 +52,29 @@ type QueryRower interface {
 	QueryRow(query string, args ...interface{}) RowScanner
 }
 
+// QueryRowerContext is the interface that wraps the QueryRow method.
+//
+// QueryRowContext executes the given query using given context as implemented by database/sql.QueryRowContext.
+type QueryRowerContext interface {
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner
+}
+
 // BaseRunner groups the Execer and Queryer interfaces.
 type BaseRunner interface {
 	Execer
+	ExecerContext
 	Queryer
+	QueryerContext
 }
 
 // Runner groups the Execer, Queryer, and QueryRower interfaces.
 type Runner interface {
 	Execer
+	ExecerContext
 	Queryer
+	QueryerContext
 	QueryRower
-}
-
-// DBRunner wraps sql.DB to implement Runner.
-type dbRunner struct {
-	*sql.DB
-}
-
-func (r *dbRunner) QueryRow(query string, args ...interface{}) RowScanner {
-	return r.DB.QueryRow(query, args...)
-}
-
-type txRunner struct {
-	*sql.Tx
-}
-
-func (r *txRunner) QueryRow(query string, args ...interface{}) RowScanner {
-	return r.Tx.QueryRow(query, args...)
+	QueryRowerContext
 }
 
 // ErrRunnerNotSet is returned by methods that need a Runner if it isn't set.
@@ -82,6 +92,15 @@ func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
 	return db.Exec(query, args...)
 }
 
+// ExecWithContext Execs the SQL returned by s with db.
+func ExecWithContext(ctx context.Context, db ExecerContext, s Sqlizer) (res sql.Result, err error) {
+	query, args, err := s.ToSql()
+	if err != nil {
+		return
+	}
+	return db.ExecContext(ctx, query, args...)
+}
+
 // QueryWith Querys the SQL returned by s with db.
 func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
 	query, args, err := s.ToSql()
@@ -91,8 +110,23 @@ func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
 	return db.Query(query, args...)
 }
 
+// QueryWithContext Querys the SQL returned by s with db.
+func QueryWithContext(ctx context.Context, db QueryerContext, s Sqlizer) (rows *sql.Rows, err error) {
+	query, args, err := s.ToSql()
+	if err != nil {
+		return
+	}
+	return db.QueryContext(ctx, query, args...)
+}
+
 // QueryRowWith QueryRows the SQL returned by s with db.
 func QueryRowWith(db QueryRower, s Sqlizer) RowScanner {
 	query, args, err := s.ToSql()
 	return &Row{RowScanner: db.QueryRow(query, args...), err: err}
+}
+
+// QueryRowWithContext QueryRows the SQL returned by s with db.
+func QueryRowWithContext(ctx context.Context, db QueryRowerContext, s Sqlizer) RowScanner {
+	query, args, err := s.ToSql()
+	return &Row{RowScanner: db.QueryRowContext(ctx, query, args...), err: err}
 }

--- a/sqrl.go
+++ b/sqrl.go
@@ -83,6 +83,9 @@ var ErrRunnerNotSet = fmt.Errorf("cannot run; no Runner set (RunWith)")
 // ErrRunnerNotQueryRunner is returned by QueryRow if the RunWith value doesn't implement QueryRower.
 var ErrRunnerNotQueryRunner = fmt.Errorf("cannot QueryRow; Runner is not a QueryRower")
 
+// ErrRunnerNotQueryRunnerContext is returned by QueryRowContext if the RunWith value doesn't implement QueryRowerContext.
+var ErrRunnerNotQueryRunnerContext = fmt.Errorf("cannot QueryRow; Runner is not a QueryRowerContext")
+
 // ExecWith Execs the SQL returned by s with db.
 func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
 	query, args, err := s.ToSql()

--- a/sqrl_test.go
+++ b/sqrl_test.go
@@ -1,6 +1,7 @@
 package sqrl
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -29,7 +30,19 @@ func (s *DBStub) Prepare(query string) (*sql.Stmt, error) {
 	return nil, nil
 }
 
+func (s *DBStub) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	s.LastPrepareSql = query
+	s.PrepareCount++
+	return nil, nil
+}
+
 func (s *DBStub) Exec(query string, args ...interface{}) (sql.Result, error) {
+	s.LastExecSql = query
+	s.LastExecArgs = args
+	return nil, nil
+}
+
+func (s *DBStub) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	s.LastExecSql = query
 	s.LastExecArgs = args
 	return nil, nil
@@ -41,7 +54,19 @@ func (s *DBStub) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	return nil, nil
 }
 
+func (s *DBStub) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	s.LastQuerySql = query
+	s.LastQueryArgs = args
+	return nil, nil
+}
+
 func (s *DBStub) QueryRow(query string, args ...interface{}) RowScanner {
+	s.LastQueryRowSql = query
+	s.LastQueryRowArgs = args
+	return &Row{RowScanner: &RowStub{}}
+}
+
+func (s *DBStub) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
 	s.LastQueryRowSql = query
 	s.LastQueryRowArgs = args
 	return &Row{RowScanner: &RowStub{}}

--- a/update.go
+++ b/update.go
@@ -2,6 +2,7 @@ package sqrl
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"sort"
@@ -47,11 +48,15 @@ func (b *UpdateBuilder) RunWith(runner BaseRunner) *UpdateBuilder {
 
 // Exec builds and Execs the query with the Runner set by RunWith.
 func (b *UpdateBuilder) Exec() (sql.Result, error) {
+	return b.ExecContext(context.Background())
+}
+
+// ExecContext builds and Execs the query with the Runner set by RunWith using given context.
+func (b *UpdateBuilder) ExecContext(ctx context.Context) (sql.Result, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
 	}
-
-	return ExecWith(b.runWith, b)
+	return ExecWithContext(ctx, b.runWith, b)
 }
 
 // PlaceholderFormat sets PlaceholderFormat (e.g. Question or Dollar) for the

--- a/update_test.go
+++ b/update_test.go
@@ -1,6 +1,7 @@
 package sqrl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,11 +75,17 @@ func TestUpdateBuilderRunners(t *testing.T) {
 
 	b.Exec()
 	assert.Equal(t, expectedSql, db.LastExecSql)
+
+	b.ExecContext(context.TODO())
+	assert.Equal(t, expectedSql, db.LastExecSql)
 }
 
 func TestUpdateBuilderNoRunner(t *testing.T) {
 	b := Update("test").Set("x", 1)
 
 	_, err := b.Exec()
+	assert.Equal(t, ErrRunnerNotSet, err)
+
+	_, err = b.ExecContext(context.TODO())
 	assert.Equal(t, ErrRunnerNotSet, err)
 }


### PR DESCRIPTION
Adds support of `context.Context` to database-related operations. Should not affect query building.