### PR TITLE
Add support for Query and QueryRow in UPDATE and DELETE statements

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -39,7 +39,7 @@ func (b *InsertBuilder) Exec() (sql.Result, error) {
 	return b.ExecContext(context.Background())
 }
 
-// Exec builds and Execs the query with the Runner set by RunWith using given context.
+// ExecContext builds and Execs the query with the Runner set by RunWith using given context.
 func (b *InsertBuilder) ExecContext(ctx context.Context) (sql.Result, error) {
 	if b.runWith == nil {
 		return nil, ErrRunnerNotSet
@@ -249,7 +249,6 @@ func (b *InsertBuilder) SetMap(clauses map[string]interface{}) *InsertBuilder {
 
 	b.columns = cols
 	b.values = [][]interface{}{vals}
-
 	return b
 }
 


### PR DESCRIPTION
PostgreSQL allows to build the following queries:

    UPDATE tbl SET col1 = 'val' WHERE id = 1 RETURNING col2;

    DELETE FROM tbl WHERE id = 1 RETURNING col1;

This patch will allow to call `Query`, `QueryRow` and `Scan` directly from `UpdateBuilder` and `DeleteBuilder`.