### PR TITLE
Add Union/UnionAll support

### DIFF
--- a/select.go
+++ b/select.go
@@ -234,7 +234,8 @@ func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
 // Column adds a result column to the query.
 // Unlike Columns, Column accepts args which will be bound to placeholders in
 // the columns string, for example:
-//   Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
+//
+//	Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
 func (b *SelectBuilder) Column(column interface{}, args ...interface{}) *SelectBuilder {
 	b.columns = append(b.columns, newPart(column, args...))
 
@@ -339,6 +340,13 @@ func (b *SelectBuilder) Offset(offset uint64) *SelectBuilder {
 	return b
 }
 
+// Union adds a UNION combination part
+func (b *SelectBuilder) Union(other *SelectBuilder) *SelectBuilder {
+	b.combiningParts = append(b.combiningParts, Expr("UNION"), other)
+	return b
+}
+
+// UnionAll adds a UNION ALL combination part
 func (b *SelectBuilder) UnionAll(other *SelectBuilder) *SelectBuilder {
 	b.combiningParts = append(b.combiningParts, Expr("UNION ALL"), other)
 	return b

--- a/select_test.go
+++ b/select_test.go
@@ -96,7 +96,6 @@ func TestSelectBuilderZeroOffsetLimit(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 }
 
-
 func TestSelectBuilderFromSelect(t *testing.T) {
 	subQ := Select("c").From("d").Where(Eq{"i": 0})
 	b := Select("a", "b").FromSelect(subQ, "subq")
@@ -107,6 +106,20 @@ func TestSelectBuilderFromSelect(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 
 	expectedArgs := []interface{}{0}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSelectBuilderCombiners(t *testing.T) {
+	b := Select("a", "b").From("e").Where("d = ?", 1).
+		UnionAll(Select("a", "b").From("f").Where("c = ?", 0))
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT a, b FROM e WHERE d = ? " +
+		"UNION ALL SELECT a, b FROM f WHERE c = ?"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{1, 0}
 	assert.Equal(t, expectedArgs, args)
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -110,17 +110,29 @@ func TestSelectBuilderFromSelect(t *testing.T) {
 }
 
 func TestSelectBuilderCombiners(t *testing.T) {
-	b := Select("a", "b").From("e").Where("d = ?", 1).
-		UnionAll(Select("a", "b").From("f").Where("c = ?", 0))
-	sql, args, err := b.ToSql()
+	unionQ := Select("a", "b").From("e").Where("d = ?", 1).
+		Union(Select("a", "b").From("f").Where("c = ?", 0))
+	unionSql, unionArgs, err := unionQ.ToSql()
 	assert.NoError(t, err)
 
 	expectedSql := "SELECT a, b FROM e WHERE d = ? " +
-		"UNION ALL SELECT a, b FROM f WHERE c = ?"
-	assert.Equal(t, expectedSql, sql)
+		"UNION SELECT a, b FROM f WHERE c = ?"
+	assert.Equal(t, expectedSql, unionSql)
 
 	expectedArgs := []interface{}{1, 0}
-	assert.Equal(t, expectedArgs, args)
+	assert.Equal(t, expectedArgs, unionArgs)
+
+	unionAllQ := Select("a", "b").From("e").Where("d = ?", 1).
+		UnionAll(Select("a", "b").From("f").Where("c = ?", 0))
+	unionAllSql, unionAllArgs, err := unionAllQ.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql = "SELECT a, b FROM e WHERE d = ? " +
+		"UNION ALL SELECT a, b FROM f WHERE c = ?"
+	assert.Equal(t, expectedSql, unionAllSql)
+
+	expectedArgs = []interface{}{1, 0}
+	assert.Equal(t, expectedArgs, unionAllArgs)
 }
 
 func TestSelectBuilderToSqlErr(t *testing.T) {


### PR DESCRIPTION
I've found myself needing first-class support recently for a lot of more advanced SQL features, such that parameters are used correctly, and finding neither `Prefix` nor `Suffix` really work for what I'm doing. This is the first of a handful of small PRs adding support for some of these features.

This one adds `Union` and `UnionAll` support. It adds the target query to a new internal storage part, `combiningParts`, which could also be used in the future to support `INTERSECT` or `EXCEPT` combining clauses.