### PR TITLE
Add SelectBuilder.FromValues

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -17,7 +17,8 @@ type expr struct {
 // Expr builds value expressions for InsertBuilder and UpdateBuilder.
 //
 // Ex:
-//     .Values(Expr("FROM_UNIXTIME(?)", t))
+//
+//	.Values(Expr("FROM_UNIXTIME(?)", t))
 func Expr(sql string, args ...interface{}) expr {
 	return expr{sql: sql, args: args}
 }
@@ -81,7 +82,8 @@ type aliasExpr struct {
 // Alias allows to define alias for column in SelectBuilder. Useful when column is
 // defined as complex expression like IF or CASE
 // Ex:
-//		.Column(Alias(caseStmt, "case_column"))
+//
+//	.Column(Alias(caseStmt, "case_column"))
 func Alias(expr Sqlizer, alias string) aliasExpr {
 	return aliasExpr{expr, alias}
 }
@@ -96,15 +98,16 @@ func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
 
 // Eq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(Eq{"id": 1})
+//
+//	.Where(Eq{"id": 1})
 type Eq map[string]interface{}
 
 func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 	var (
-		exprs      []string
-		equalOpr   = "="
-		inOpr      = "IN"
-		nullOpr    = "IS"
+		exprs       []string
+		equalOpr    = "="
+		inOpr       = "IN"
+		nullOpr     = "IS"
 		inEmptyExpr = "(1=0)" // Portable FALSE
 	)
 
@@ -159,7 +162,8 @@ func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
 
 // NotEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(NotEq{"id": 1}) == "id <> 1"
+//
+//	.Where(NotEq{"id": 1}) == "id <> 1"
 type NotEq Eq
 
 // ToSql builds the query into a SQL string and bound args.
@@ -169,7 +173,8 @@ func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
 
 // Lt is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(Lt{"id": 1})
+//
+//	.Where(Lt{"id": 1})
 type Lt map[string]interface{}
 
 func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err error) {
@@ -220,7 +225,8 @@ func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
 
 // LtOrEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(LtOrEq{"id": 1}) == "id <= 1"
+//
+//	.Where(LtOrEq{"id": 1}) == "id <= 1"
 type LtOrEq Lt
 
 func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
@@ -229,7 +235,8 @@ func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
 
 // Gt is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(Gt{"id": 1}) == "id > 1"
+//
+//	.Where(Gt{"id": 1}) == "id > 1"
 type Gt Lt
 
 func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
@@ -238,7 +245,8 @@ func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
 
 // GtOrEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//     .Where(GtOrEq{"id": 1}) == "id >= 1"
+//
+//	.Where(GtOrEq{"id": 1}) == "id >= 1"
 type GtOrEq Lt
 
 func (gtOrEq GtOrEq) ToSql() (sql string, args []interface{}, err error) {
@@ -267,7 +275,8 @@ func (c conj) join(sep string) (sql string, args []interface{}, err error) {
 
 // And is syntactic sugar that glues where/having parts with AND clause
 // Ex:
-//     .Where(And{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
+//
+//	.Where(And{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
 type And conj
 
 // ToSql builds the query into a SQL string and bound args.
@@ -277,7 +286,8 @@ func (a And) ToSql() (string, []interface{}, error) {
 
 // Or is syntactic sugar that glues where/having parts with OR clause
 // Ex:
-//     .Where(Or{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
+//
+//	.Where(Or{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
 type Or conj
 
 // ToSql builds the query into a SQL string and bound args.

--- a/expr.go
+++ b/expr.go
@@ -17,8 +17,7 @@ type expr struct {
 // Expr builds value expressions for InsertBuilder and UpdateBuilder.
 //
 // Ex:
-//
-//	.Values(Expr("FROM_UNIXTIME(?)", t))
+//     .Values(Expr("FROM_UNIXTIME(?)", t))
 func Expr(sql string, args ...interface{}) expr {
 	return expr{sql: sql, args: args}
 }
@@ -82,8 +81,7 @@ type aliasExpr struct {
 // Alias allows to define alias for column in SelectBuilder. Useful when column is
 // defined as complex expression like IF or CASE
 // Ex:
-//
-//	.Column(Alias(caseStmt, "case_column"))
+//		.Column(Alias(caseStmt, "case_column"))
 func Alias(expr Sqlizer, alias string) aliasExpr {
 	return aliasExpr{expr, alias}
 }
@@ -98,16 +96,15 @@ func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
 
 // Eq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(Eq{"id": 1})
+//     .Where(Eq{"id": 1})
 type Eq map[string]interface{}
 
 func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 	var (
-		exprs       []string
-		equalOpr    = "="
-		inOpr       = "IN"
-		nullOpr     = "IS"
+		exprs      []string
+		equalOpr   = "="
+		inOpr      = "IN"
+		nullOpr    = "IS"
 		inEmptyExpr = "(1=0)" // Portable FALSE
 	)
 
@@ -162,8 +159,7 @@ func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
 
 // NotEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(NotEq{"id": 1}) == "id <> 1"
+//     .Where(NotEq{"id": 1}) == "id <> 1"
 type NotEq Eq
 
 // ToSql builds the query into a SQL string and bound args.
@@ -173,8 +169,7 @@ func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
 
 // Lt is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(Lt{"id": 1})
+//     .Where(Lt{"id": 1})
 type Lt map[string]interface{}
 
 func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err error) {
@@ -225,8 +220,7 @@ func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
 
 // LtOrEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(LtOrEq{"id": 1}) == "id <= 1"
+//     .Where(LtOrEq{"id": 1}) == "id <= 1"
 type LtOrEq Lt
 
 func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
@@ -235,8 +229,7 @@ func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
 
 // Gt is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(Gt{"id": 1}) == "id > 1"
+//     .Where(Gt{"id": 1}) == "id > 1"
 type Gt Lt
 
 func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
@@ -245,8 +238,7 @@ func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
 
 // GtOrEq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
-//
-//	.Where(GtOrEq{"id": 1}) == "id >= 1"
+//     .Where(GtOrEq{"id": 1}) == "id >= 1"
 type GtOrEq Lt
 
 func (gtOrEq GtOrEq) ToSql() (sql string, args []interface{}, err error) {
@@ -275,8 +267,7 @@ func (c conj) join(sep string) (sql string, args []interface{}, err error) {
 
 // And is syntactic sugar that glues where/having parts with AND clause
 // Ex:
-//
-//	.Where(And{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
+//     .Where(And{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
 type And conj
 
 // ToSql builds the query into a SQL string and bound args.
@@ -286,8 +277,7 @@ func (a And) ToSql() (string, []interface{}, error) {
 
 // Or is syntactic sugar that glues where/having parts with OR clause
 // Ex:
-//
-//	.Where(Or{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
+//     .Where(Or{Expr("a > ?", 15), Expr("b < ?", 20), Expr("c is TRUE")})
 type Or conj
 
 // ToSql builds the query into a SQL string and bound args.

--- a/select.go
+++ b/select.go
@@ -225,8 +225,7 @@ func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
 // Column adds a result column to the query.
 // Unlike Columns, Column accepts args which will be bound to placeholders in
 // the columns string, for example:
-//
-//	Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
+//   Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
 func (b *SelectBuilder) Column(column interface{}, args ...interface{}) *SelectBuilder {
 	b.columns = append(b.columns, newPart(column, args...))
 

--- a/select.go
+++ b/select.go
@@ -225,7 +225,8 @@ func (b *SelectBuilder) Columns(columns ...string) *SelectBuilder {
 // Column adds a result column to the query.
 // Unlike Columns, Column accepts args which will be bound to placeholders in
 // the columns string, for example:
-//   Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
+//
+//	Column("IF(col IN ("+Placeholders(3)+"), 1, 0) as col", 1, 2, 3)
 func (b *SelectBuilder) Column(column interface{}, args ...interface{}) *SelectBuilder {
 	b.columns = append(b.columns, newPart(column, args...))
 
@@ -246,6 +247,13 @@ func (b *SelectBuilder) From(tables ...string) *SelectBuilder {
 // FromSelect sets a subquery into the FROM clause of the query.
 func (b *SelectBuilder) FromSelect(from *SelectBuilder, alias string) *SelectBuilder {
 	b.fromParts = append(b.fromParts, Alias(from, alias))
+	return b
+}
+
+// FromValues selects from a VALUES expression in the FROM clause of the query.
+func (b *SelectBuilder) FromValues(from *ValuesBuilder, alias string, columns ...string) *SelectBuilder {
+	aliasName := alias + "(" + strings.Join(columns, ", ") + ")"
+	b.fromParts = append(b.fromParts, Alias(from, aliasName))
 	return b
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -96,6 +96,7 @@ func TestSelectBuilderZeroOffsetLimit(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 }
 
+
 func TestSelectBuilderFromSelect(t *testing.T) {
 	subQ := Select("c").From("d").Where(Eq{"i": 0})
 	b := Select("a", "b").FromSelect(subQ, "subq")

--- a/select_test.go
+++ b/select_test.go
@@ -96,7 +96,6 @@ func TestSelectBuilderZeroOffsetLimit(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 }
 
-
 func TestSelectBuilderFromSelect(t *testing.T) {
 	subQ := Select("c").From("d").Where(Eq{"i": 0})
 	b := Select("a", "b").FromSelect(subQ, "subq")
@@ -107,6 +106,18 @@ func TestSelectBuilderFromSelect(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 
 	expectedArgs := []interface{}{0}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSelectBuilderFromValues(t *testing.T) {
+	b := Select("name").FromValues(Values("foo").Values("bar"), "d", "name")
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT name FROM (VALUES (?),(?)) AS d(name)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{"foo", "bar"}
 	assert.Equal(t, expectedArgs, args)
 }
 

--- a/statement.go
+++ b/statement.go
@@ -89,8 +89,12 @@ func Case(what ...interface{}) *CaseBuilder {
 // Values returns a new ValuesBuilder, with the provided arguments as the first row.
 // Added to support `SelectBuilder.FromValues`
 func Values(values ...interface{}) *ValuesBuilder {
+	intialVals := make([][]interface{}, 0)
+	if len(values) > 0 {
+		intialVals = append(intialVals, values)
+	}
 	return &ValuesBuilder{
 		StatementBuilderType: StatementBuilder,
-		values:               [][]interface{}{values},
+		values:               intialVals,
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -85,3 +85,12 @@ func Case(what ...interface{}) *CaseBuilder {
 	}
 	return b
 }
+
+// Values returns a new ValuesBuilder, with the provided arguments as the first row.
+// Added to support `SelectBuilder.FromValues`
+func Values(values ...interface{}) *ValuesBuilder {
+	return &ValuesBuilder{
+		StatementBuilderType: StatementBuilder,
+		values:               [][]interface{}{values},
+	}
+}

--- a/values.go
+++ b/values.go
@@ -1,0 +1,58 @@
+package sqrl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// ValuesBuilder is a collection of rows
+// Provided to support `SelectBuilder.FromValues`
+type ValuesBuilder struct {
+	StatementBuilderType
+
+	values [][]interface{}
+}
+
+// Add another row to the ValuesBuilder
+func (vb *ValuesBuilder) Values(values ...interface{}) *ValuesBuilder {
+	vb.values = append(vb.values, values)
+	return vb
+}
+
+func (vb *ValuesBuilder) ToSql() (sqlStr string, args []interface{}, err error) {
+	sql := &bytes.Buffer{}
+
+	sql.WriteString("VALUES ")
+	if len(vb.values) == 0 {
+		err = fmt.Errorf("values list is empty")
+		return
+	}
+
+	valuesStrings := make([]string, len(vb.values))
+	for r, row := range vb.values {
+		valueStrings := make([]string, len(row))
+		for v, val := range row {
+			switch typedVal := val.(type) {
+			case expr:
+				valueStrings[v] = typedVal.sql
+				args = append(args, typedVal.args...)
+			case Sqlizer:
+				valSql, valArgs, err := typedVal.ToSql()
+				if err != nil {
+					return "", args, err
+				}
+				valueStrings[v] = valSql
+				args = append(args, valArgs...)
+			default:
+				valueStrings[v] = "?"
+				args = append(args, val)
+			}
+
+		}
+		valuesStrings[r] = fmt.Sprintf("(%s)", strings.Join(valueStrings, ","))
+	}
+	sql.WriteString(strings.Join(valuesStrings, ","))
+	sqlStr, err = vb.placeholderFormat.ReplacePlaceholders(sql.String())
+	return
+}


### PR DESCRIPTION
This is another need I've had in dynamic SQL building: `SELECT something FROM (VALUES (...) ) AS vals(something)`. This pattern can be incredibly useful in joins or CTE-style queries where you have small lookup table you need to use as part of the query.

`From` just takes tables, `FromSelect` wants another SelectBuilder, but I couldn't find a way to get a parameterized `VALUES` clause in there that would properly respect parameter position. 

This necessitated creating a new builder type: `ValuesBuilder`. It would be fairly easy to switch `InsertBuilder.Values` to using this under the hood if the pattern is useful.